### PR TITLE
Apply code review suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository contains a simple kinematic simulator for the Modern Robotics
 capstone project.  The main function `NextState` propagates the robot
 configuration forward one time step given wheel and joint commands.
 
+The simulator requires Python 3.10+ and the `modern_robotics` library. Install
+all dependencies using `pip install -r requirements.txt`.
+
 The `driver` module can generate CSV files compatible with the CoppeliaSim
 scenes.  Example usage for the first sanity check scenario is:
 

--- a/modern_robotics_sim/driver.py
+++ b/modern_robotics_sim/driver.py
@@ -13,6 +13,8 @@ def parse_args():
     p.add_argument('--dt', type=float, default=0.01)
     p.add_argument('--speed-limit', type=float, default=20.0)
     p.add_argument('--steps', type=int, default=100)
+    p.add_argument('--gripper', type=int, choices=[0, 1], default=0,
+                   help='gripper open (0) or closed (1)')
     return p.parse_args()
 
 
@@ -30,10 +32,10 @@ def main():
     config = load_initial(args.initial)
     controls = np.array(args.controls, dtype=float)
 
-    out_rows = []
+    out_rows = [list(config) + [args.gripper]]
     for _ in range(args.steps):
         config = NextState(config, controls, args.dt, args.speed_limit)
-        out_rows.append(list(config) + [0])
+        out_rows.append(list(config) + [args.gripper])
 
     with open(args.output, 'w', newline='') as f:
         writer = csv.writer(f)

--- a/modern_robotics_sim/next_state.py
+++ b/modern_robotics_sim/next_state.py
@@ -1,6 +1,12 @@
 import numpy as np
 from modern_robotics import VecTose3, MatrixExp6
 
+# Geometry constants shared with the CoppeliaSim scenes
+RADIUS = 0.0475
+L = 0.235
+W = 0.15
+H = 0.0963
+
 
 def NextState(config, controls, dt, speed_limit):
     """Advance the robot configuration by one time step."""
@@ -12,11 +18,6 @@ def NextState(config, controls, dt, speed_limit):
     if controls.shape != (9,):
         raise ValueError("controls must be length 9")
 
-    # Constants
-    r = 0.0475
-    l = 0.235
-    w = 0.15
-    h = 0.0963
 
     # Clip control inputs
     controls_clipped = np.clip(controls, -speed_limit, speed_limit)
@@ -31,26 +32,28 @@ def NextState(config, controls, dt, speed_limit):
     wheels = config[8:]
 
     # Chassis kinematics
-    F = (r / 4) * np.array([
-        [-1/(l+w),  1/(l+w),  1/(l+w), -1/(l+w)],
-        [     1  ,       1  ,       1  ,      1 ],
-        [    -1  ,       1  ,      -1  ,      1 ],
+    F = (RADIUS / 4) * np.array([
+        [-1/(L+W),  1/(L+W),  1/(L+W), -1/(L+W)],
+        [     1   ,       1 ,       1 ,      1 ],
+        [    -1   ,       1 ,      -1 ,      1 ],
     ])
 
     Vb = F @ u
-    # 6D body twist [wx, wy, wz, vx, vy, vz]
+    # 6D body twist [wx, wy, wz, vx, vy, vz]; vz = 0 for planar chassis
     Vb6 = np.array([0.0, 0.0, Vb[0], Vb[1], Vb[2], 0.0])
 
     Tsb = np.array([
         [np.cos(phi), -np.sin(phi), 0, x],
         [np.sin(phi),  np.cos(phi), 0, y],
-        [0,            0,           1, h],
+        [0,            0,           1, H],
         [0,            0,           0, 1],
     ])
 
     Tsb_new = Tsb @ MatrixExp6(VecTose3(Vb6 * dt))
 
     phi_new = np.arctan2(Tsb_new[1, 0], Tsb_new[0, 0])
+    # Wrap heading to [-pi, pi] for long runs
+    phi_new = (phi_new + np.pi) % (2 * np.pi) - np.pi
     x_new = Tsb_new[0, 3]
     y_new = Tsb_new[1, 3]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+modern_robotics

--- a/tests/test_next_state.py
+++ b/tests/test_next_state.py
@@ -18,6 +18,7 @@ def test_forward_x():
     controls = [10, 10, 10, 10] + [0]*5
     cfg = run_for_one_second(controls)
     assert np.allclose(cfg[1], 0.475, atol=1e-3)
+    assert np.allclose(cfg[8], 10.0, atol=1e-6)
 
 
 def test_forward_y():
@@ -30,3 +31,9 @@ def test_rotation():
     controls = [-10, 10, 10, -10] + [0]*5
     cfg = run_for_one_second(controls)
     assert np.allclose(cfg[0], 1.234, atol=1e-3)
+
+
+def test_speed_limit():
+    controls = [10, 10, 10, 10] + [0]*5
+    cfg = run_for_one_second(controls, speed_limit=5.0)
+    assert np.allclose(cfg[1], 0.2375, atol=1e-3)


### PR DESCRIPTION
## Summary
- wrap heading to `[-pi, pi]` and document zero vertical speed
- expose geometry constants and use in `NextState`
- allow CLI to set gripper state and include initial row in CSV
- document Python requirements and add `requirements.txt`
- expand tests for wheel angles and speed limit behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686acfcb5ec88332aab81e80e44fecb2