### PR TITLE
Improve trajectory generator robustness

### DIFF
--- a/tests/test_trajectory_generator.py
+++ b/tests/test_trajectory_generator.py
@@ -144,3 +144,12 @@ def test_comprehensive_trajectory():
     print(f"Generated trajectory with {len(traj)} points")
     print(f"Trajectory duration: {len(traj) * DT_REF:.2f} seconds")
     print(f"Gripper states: {unique_states}")
+
+
+def test_k_divisible():
+    poses = create_simple_poses()
+    k = 2
+    traj = TrajectoryGenerator(*poses, k=k)
+    assert traj.shape[1] == 13
+    assert len(traj) % k == 0
+    assert set(np.unique(traj[:, -1])).issubset({OPEN_STATE, CLOSED_STATE})


### PR DESCRIPTION
## Summary
- validate speed cap arguments
- unify dwell segment sample count and add skip_first
- drop final pose, assert orientation continuity, and add divisibility test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7e0ee2a88332bf52caaf5b667fe5