### PR TITLE
Fix downward gripper orientation

### DIFF
--- a/code/enhanced_scenarios.py
+++ b/code/enhanced_scenarios.py
@@ -34,9 +34,9 @@ except ImportError:
         return Tsc_init, Tsc_goal
     
     def create_grasp_transforms():
-        """Fallback grasp transforms."""
-        Tce_grasp = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0.02], [0, 0, 0, 1]])
-        Tce_standoff = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0.12], [0, 0, 0, 1]])
+        """Fallback grasp transforms with downward gripper orientation."""
+        Tce_grasp = np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0.02], [0, 0, 0, 1]])
+        Tce_standoff = np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0.12], [0, 0, 0, 1]])
         return Tce_grasp, Tce_standoff
     
     def create_initial_ee_pose():

--- a/code/run_capstone.py
+++ b/code/run_capstone.py
@@ -93,19 +93,19 @@ def create_grasp_transforms():
         Tce_grasp: 4x4 SE(3) - grasp transform relative to cube
         Tce_standoff: 4x4 SE(3) - standoff transform relative to cube
     """
-    # Grasp pose aligned with cube axes (no rotation)
+    # Grasp pose rotated so the gripper points downward (180° about y-axis)
     Tce_grasp = np.array([
-        [1, 0, 0, 0],
+        [0, 0, 1, 0],
         [0, 1, 0, 0],
-        [0, 0, 1, 0.02],
+        [-1, 0, 0, 0.02],
         [0, 0, 0, 1]
     ])
 
-    # Standoff pose 10 cm above the grasp pose
+    # Standoff pose directly above the cube with same orientation
     Tce_standoff = np.array([
-        [1, 0, 0, 0],
+        [0, 0, 1, 0],
         [0, 1, 0, 0],
-        [0, 0, 1, 0.12],
+        [-1, 0, 0, 0.12],
         [0, 0, 0, 1]
     ])
     

--- a/code/tests/test_milestone4.py
+++ b/code/tests/test_milestone4.py
@@ -101,18 +101,18 @@ class TestMilestone4Setup:
         
         # Test grasp transform
         expected_grasp = np.array([
-            [1, 0, 0, 0],
+            [0, 0, 1, 0],
             [0, 1, 0, 0],
-            [0, 0, 1, 0.02],
+            [-1, 0, 0, 0.02],
             [0, 0, 0, 1]
         ])
         np.testing.assert_allclose(Tce_grasp, expected_grasp, rtol=1e-6)
         
         # Test standoff transform (grasp + 0.10m in z)
         expected_standoff = np.array([
-            [1, 0, 0, 0],
-            [0, 1, 0, 0], 
-            [0, 0, 1, 0.12],
+            [0, 0, 1, 0],
+            [0, 1, 0, 0],
+            [-1, 0, 0, 0.12],
             [0, 0, 0, 1]
         ])
         np.testing.assert_allclose(Tce_standoff, expected_standoff, rtol=1e-6)


### PR DESCRIPTION
## Summary
- point the gripper downward in `create_grasp_transforms`
- keep fallback scenario consistent with new orientation
- update the test to expect the downward pose

## Testing
- `pytest code/tests/test_milestone4.py::TestMilestone4Setup::test_grasp_transforms -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7b079cbc8332a4c6d4ee7db9f4a4