### PR TITLE
Fix end-effector pose height calculation

### DIFF
--- a/code/run_capstone.py
+++ b/code/run_capstone.py
@@ -26,6 +26,7 @@ from .trajectory_generator import TrajectoryGenerator
 from .feedback_control import FeedbackControl, FeedbackControlWithJointLimits, compute_jacobian
 from .feedback_control import R, L, W, DT, TB0, M0E, BLIST, INV_TB0, PINV_TOLERANCE
 from .feedback_control import checkJointLimits, enforceJointLimits
+from .next_state import H
 
 
 # Fixed constants for Milestone 4
@@ -95,11 +96,11 @@ def create_grasp_transforms():
     """
     # Grasp pose rotated so the gripper points downward
     # (90° about the y-axis so the gripper's closing direction is along −Z).
-    # Translation is at the cube center.
+    # Translation is 0.02m above the cube center (Scene 6 spec).
     Tce_grasp = np.array([
         [0, 0, 1, 0],
         [0, 1, 0, 0],
-        [-1, 0, 0, 0],
+        [-1, 0, 0, 0.02],
         [0, 0, 0, 1]
     ])
 
@@ -108,7 +109,7 @@ def create_grasp_transforms():
     Tce_standoff = np.array([
         [0, 0, 1, 0],
         [0, 1, 0, 0],
-        [-1, 0, 0, 0.1],
+        [-1, 0, 0, 0.12],
         [0, 0, 0, 1]
     ])
     
@@ -223,7 +224,7 @@ def compute_current_ee_pose(config):
     Tsb = np.array([
         [cos_phi, -sin_phi, 0, x],
         [sin_phi,  cos_phi, 0, y],
-        [0,        0,       1, 0],
+        [0,        0,       1, H],
         [0,        0,       0, 1]
     ])
     

--- a/code/tests/test_milestone4.py
+++ b/code/tests/test_milestone4.py
@@ -196,7 +196,7 @@ class TestMilestone4Integration:
         np.testing.assert_allclose(T[3, :], [0, 0, 0, 1], rtol=1e-6)
         
         # Position should be forward kinematics result
-        expected_pos = np.array([0.1662 + 0.033, 0, 0.0026 + 0.6546])  # TB0 + M0E positions
+        expected_pos = np.array([0.1662 + 0.033, 0, 0.0963 + 0.0026 + 0.6546])  # H + TB0 + M0E positions
         np.testing.assert_allclose(T[:3, 3], expected_pos, rtol=1e-3)
         
     def test_feedback_control_integration(self):


### PR DESCRIPTION
## Summary
- account for chassis height when computing end-effector pose
- adjust grasp and standoff transforms
- update unit test expectations

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c013c6f688332892781830f61db90