### PR TITLE
Fix best scenario gains for proper cube pickup

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -203,8 +203,13 @@ def run_best_scenario(output_dir=None):
     print("="*60)
     
     # Well-tuned feedforward + PI controller
-    Kp = np.diag([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])  # Very small gains like milestone3
-    Ki = np.diag([0.001, 0.001, 0.001, 0.001, 0.001, 0.001])  # Minimal integral
+    # Use moderate gains that can correct large initial errors while
+    # still providing smooth convergence. The previous values were
+    # unintentionally tiny (0.1 and 0.001), leaving the robot far from
+    # the cube and causing pickup failure. These gains match the values
+    # documented below.
+    Kp = np.diag([4, 4, 4, 4, 4, 4])
+    Ki = np.diag([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
     
     return run_scenario(
         "best", Kp, Ki,

--- a/code/scenarios.py
+++ b/code/scenarios.py
@@ -216,8 +216,10 @@ def run_best_scenario(output_dir="results/best"):
     print("=== Running Best Performance Scenario ===")
     
     # Well-tuned gains for good performance with large initial errors
-    Kp = np.diag([3, 3, 3, 3, 3, 3])  # Moderate proportional gains
-    Ki = np.diag([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])  # Small integral gains
+    # Align with ``code.main`` to generate the official results/best data.
+    # Higher gains ensure the robot reaches the cube reliably.
+    Kp = np.diag([4, 4, 4, 4, 4, 4])
+    Ki = np.diag([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
     
     Tsc_init, Tsc_goal = create_default_cube_poses()
     Tce_grasp, Tce_standoff = create_grasp_transforms()


### PR DESCRIPTION
## Summary
- increase Kp/Ki gains in `run_best_scenario` to robust 4/0.2 values, ensuring the controller can reach the cube
- keep `scenarios.run_best_scenario` in sync with the main entry point

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b8b2bcd483328f0fc2738a27e1f3