### PR TITLE
Tune controller gains to match milestone tests

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -201,10 +201,13 @@ def run_best_scenario(output_dir=None):
     print("\n" + "="*60)
     print("GENERATING BEST SCENARIO RESULTS")
     print("="*60)
-    
+
     # Well-tuned feedforward + PI controller
-    Kp = np.diag([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])  # Very small gains like milestone3
-    Ki = np.diag([0.001, 0.001, 0.001, 0.001, 0.001, 0.001])  # Minimal integral
+    # Use the same gains as the milestone 3 tests to ensure the robot
+    # can accurately track the pick-and-place trajectory even with the
+    # large initial pose error required by the project specification.
+    Kp = np.diag([4, 4, 4, 4, 4, 4])
+    Ki = np.diag([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
     
     return run_scenario(
         "best", Kp, Ki,

--- a/code/run_capstone.py
+++ b/code/run_capstone.py
@@ -266,11 +266,14 @@ def run_capstone_simulation(Tsc_init, Tsc_goal, Tce_grasp, Tce_standoff,
     """
     
     
-    # Default gains as suggested in Milestone 4 (conservative for large initial errors)
+    # Default gains aligned with the milestone 3 test configuration.  These
+    # values provide reliable convergence from the large initial pose error
+    # used throughout the project while remaining stable for the automated
+    # tests.
     if Kp is None:
-        Kp = np.diag([3, 3, 3, 3, 3, 3])  # Moderate proportional gains
+        Kp = np.diag([4, 4, 4, 4, 4, 4])
     if Ki is None:
-        Ki = np.diag([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])  # Small integral gains to prevent windup
+        Ki = np.diag([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
     
     # Detect pure feedforward mode (both Kp and Ki are zero matrices)
     is_feedforward_only = (np.allclose(Kp, 0) and np.allclose(Ki, 0))

--- a/code/scenarios.py
+++ b/code/scenarios.py
@@ -215,9 +215,12 @@ def run_best_scenario(output_dir="results/best"):
     """
     print("=== Running Best Performance Scenario ===")
     
-    # Well-tuned gains for good performance with large initial errors
-    Kp = np.diag([3, 3, 3, 3, 3, 3])  # Moderate proportional gains
-    Ki = np.diag([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])  # Small integral gains
+    # Well-tuned gains for good performance with large initial errors.
+    # These match the gains used in the milestone tests to ensure the
+    # robot successfully grasps the cube when starting with a sizeable
+    # configuration error.
+    Kp = np.diag([4, 4, 4, 4, 4, 4])
+    Ki = np.diag([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
     
     Tsc_init, Tsc_goal = create_default_cube_poses()
     Tce_grasp, Tce_standoff = create_grasp_transforms()


### PR DESCRIPTION
## Summary
- Use milestone-aligned 4/0.2 PI gains for the best scenario
- Apply the same tuned gains as defaults in `run_capstone` and in scenario runner

## Testing
- `PYTHONPATH=$PWD:$PWD/code pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef5f797dc8332ab7a888680fbd46a