### PR TITLE
Fix grasp/standoff orientation to avoid base collision

### DIFF
--- a/code/enhanced_scenarios.py
+++ b/code/enhanced_scenarios.py
@@ -35,8 +35,18 @@ except ImportError:
     
     def create_grasp_transforms():
         """Fallback grasp transforms with downward gripper orientation."""
-        Tce_grasp = np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0.0], [0, 0, 0, 1]])
-        Tce_standoff = np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0.10], [0, 0, 0, 1]])
+        # Keep the same orientation for grasp and standoff poses so the
+        # robot approaches the cube vertically.  Using different
+        # orientations here can cause the chassis to collide with the
+        # cube while moving into position.
+        Tce_grasp = np.array([[1, 0, 0, 0],
+                              [0, -1, 0, 0],
+                              [0, 0, -1, 0.0],
+                              [0, 0, 0, 1]])
+        Tce_standoff = np.array([[1, 0, 0, 0],
+                                 [0, -1, 0, 0],
+                                 [0, 0, -1, 0.10],
+                                 [0, 0, 0, 1]])
         return Tce_grasp, Tce_standoff
     
     def create_initial_ee_pose():

--- a/code/run_capstone.py
+++ b/code/run_capstone.py
@@ -142,12 +142,17 @@ def create_grasp_transforms():
         [0, 0, 0, 1]
     ])
 
-    # Standoff pose directly above the cube with the same orientation,
-    # 10 cm higher than the grasp pose in the world Z direction.
+    # Standoff pose directly above the cube sharing the same downward
+    # orientation as the grasp pose, offset by 10 cm in the world Z
+    # direction.  The previous implementation used a different rotation,
+    # which caused the robot base to drive through the cube when
+    # approaching the grasp point.  Using the same orientation for both
+    # transforms keeps the approach vertical and prevents the base from
+    # overrunning the cube.
     Tce_standoff = np.array([
-        [0, 0, 1, 0],
-        [0, 1, 0, 0],
-        [-1, 0, 0, 0.10],
+        [1, 0, 0, 0],
+        [0, -1, 0, 0],
+        [0, 0, -1, 0.10],
         [0, 0, 0, 1]
     ])
     

--- a/code/tests/test_milestone4.py
+++ b/code/tests/test_milestone4.py
@@ -101,18 +101,18 @@ class TestMilestone4Setup:
         
         # Test grasp transform
         expected_grasp = np.array([
-            [0, 0, 1, 0],
-            [0, 1, 0, 0],
-            [-1, 0, 0, 0.0],
+            [1, 0, 0, 0],
+            [0, -1, 0, 0],
+            [0, 0, -1, 0.0],
             [0, 0, 0, 1]
         ])
         np.testing.assert_allclose(Tce_grasp, expected_grasp, rtol=1e-6)
-        
-        # Test standoff transform (grasp + 0.10m in z)
+
+        # Test standoff transform (grasp + 0.10m in world Z)
         expected_standoff = np.array([
-            [0, 0, 1, 0],
-            [0, 1, 0, 0],
-            [-1, 0, 0, 0.10],
+            [1, 0, 0, 0],
+            [0, -1, 0, 0],
+            [0, 0, -1, 0.10],
             [0, 0, 0, 1]
         ])
         np.testing.assert_allclose(Tce_standoff, expected_standoff, rtol=1e-6)


### PR DESCRIPTION
## Summary
- Ensure grasp and standoff transforms share a downward orientation
- Update enhanced scenario fallbacks to use the same orientation
- Adjust milestone 4 tests for new grasp and standoff definitions

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a068f8cd108332a998b6491c39b2de