### PR TITLE
Align main scenario gains with milestone3 tests

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -203,17 +203,18 @@ def run_best_scenario(output_dir=None):
     print("="*60)
 
     # Well-tuned feedforward + PI controller
-    # Use the same gains as the milestone 3 tests to ensure the robot
-    # can accurately track the pick-and-place trajectory even with the
-    # large initial pose error required by the project specification.
-    Kp = np.diag([4, 4, 4, 4, 4, 4])
-    Ki = np.diag([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
+    # Use the same gains as the milestone 3 tests (large error case) to
+    # ensure the robot can accurately track the pick-and-place trajectory
+    # even with the large initial pose error required by the project
+    # specification.
+    Kp = np.diag([3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    Ki = np.diag([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
     
     return run_scenario(
         "best", Kp, Ki,
         controller_description="Feedforward + PI Control",
-        gains_description="4, 4, 4, 4, 4, 4, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2",
-        notes="Well-tuned gains for smooth convergence with minimal overshoot",
+        gains_description="3, 3, 3, 3, 3, 3, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1",
+        notes="Gains aligned with test configuration for reliable convergence",
         output_dir=output_dir
     )
 

--- a/code/run_capstone.py
+++ b/code/run_capstone.py
@@ -267,13 +267,13 @@ def run_capstone_simulation(Tsc_init, Tsc_goal, Tce_grasp, Tce_standoff,
     
     
     # Default gains aligned with the milestone 3 test configuration.  These
-    # values provide reliable convergence from the large initial pose error
-    # used throughout the project while remaining stable for the automated
-    # tests.
+    # values match the "large_error" case from the tests and provide reliable
+    # convergence from the significant initial pose error used throughout the
+    # project while remaining stable for the automated tests.
     if Kp is None:
-        Kp = np.diag([4, 4, 4, 4, 4, 4])
+        Kp = np.diag([3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
     if Ki is None:
-        Ki = np.diag([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
+        Ki = np.diag([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
     
     # Detect pure feedforward mode (both Kp and Ki are zero matrices)
     is_feedforward_only = (np.allclose(Kp, 0) and np.allclose(Ki, 0))


### PR DESCRIPTION
## Summary
- Use milestone3 'large_error' gains as defaults in capstone simulation for better convergence
- Match main 'best' scenario controller gains to milestone3 tests for consistent behavior

## Testing
- `python code/test.py tests/test_milestone3.py`
- `python code/main.py best`


------
https://chatgpt.com/codex/tasks/task_e_68a234ea9e088332a693e0681453afa8